### PR TITLE
Remove macos-latest/windows-latest actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta, nightly, 1.41.0]
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -42,9 +41,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta, nightly, 1.41.0]
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Multiple builds failed due to mac-os/windows runners (timed out, illegal access, ...).
Remove them and wait for more stable mac-os/windows runners.